### PR TITLE
🔒 [security fix] Fix Stored XSS in Shipping Notes

### DIFF
--- a/app/Http/Controllers/Front/OrderController.php
+++ b/app/Http/Controllers/Front/OrderController.php
@@ -24,7 +24,7 @@ class OrderController extends Controller
             'zip' => $request->zip,
             'email' => $request->email,
             'phone' => $request->phone,
-            'notes' => $request->notes,
+            'notes' => $request->notes ? strip_tags($request->notes) : null,
         ]);
 
         #Order

--- a/resources/views/admin/shipping/detail.blade.php
+++ b/resources/views/admin/shipping/detail.blade.php
@@ -103,7 +103,7 @@
                                 <div class="form-group col-12">
                                     <label>Notes</label>
                                     <textarea class="form-control summernote-simple"
-                                        readonly>{!! $shipping->notes !!}</textarea>
+                                        readonly>{{ $shipping->notes }}</textarea>
                                 </div>
                             </div>
                         </form>

--- a/resources/views/admin/user/detail.blade.php
+++ b/resources/views/admin/user/detail.blade.php
@@ -179,7 +179,7 @@
                                                     <div class="form-group col-12">
                                                         <label>Notes</label>
                                                         <textarea class="form-control summernote-simple"
-                                                            readonly>{!! $shipping->notes !!}</textarea>
+                                                            readonly>{{ $shipping->notes }}</textarea>
                                                     </div>
                                                 </div>
                                             </form>


### PR DESCRIPTION
This PR fixes a Stored Cross-Site Scripting (XSS) vulnerability in the shipping notes field.

🎯 **What:** The vulnerability allowed an attacker to inject malicious scripts into the 'notes' field when creating an order.
⚠️ **Risk:** These scripts would execute in the browser of any administrator viewing the order details or user profile, potentially leading to session hijacking or unauthorized actions.
🛡️ **Solution:**
1. Applied `strip_tags()` to the 'notes' field in `OrderController::create` to remove any HTML tags before saving to the database.
2. Updated `admin/shipping/detail.blade.php` and `admin/user/detail.blade.php` to use escaped output `{{ $shipping->notes }}` instead of raw output `{!! $shipping->notes !!}`.

Verified with `php -l` and manual code analysis. Full test suite was not run due to environment setup constraints.

---
*PR created automatically by Jules for task [18264502017000163985](https://jules.google.com/task/18264502017000163985) started by @NeddyAP*