### PR TITLE
⚡ Optimize Shipping Search Performance

### DIFF
--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -29,23 +29,22 @@ class UserController extends Controller
         $shippings = Shipping::where('id_user', $user->id)->latest()->get();
         return view('admin.user.detail',compact('user','shippings'));
     }
-    public function shippingSearch(Request $request , $id)
+    public function shippingSearch(Request $request, $id)
     {
         $user = User::find($id);
         $search = $request->search;
-        $result = Shipping::where('id_user',$user->id)->first();
-        if($result){
-            $shippings = Shipping::where('company_name', 'like', "%" . $search . "%")
-            ->orWhere('country', 'like', "%" . $search . "%")
-            ->orWhere('name', 'like', "%" . $search . "%")
-            ->orWhere('address', 'like', "%" . $search . "%")
-            ->orWhere('state', 'like', "%" . $search . "%")
-            ->orWhere('zip', 'like', "%" . $search . "%")
-            ->orWhere('email', 'like', "%" . $search . "%")
-            ->orWhere('phone', 'like', "%" . $search . "%")->get();
-        }else{
-            $shippings = Shipping::where('id_user',$user->id)->get();
-        }
-        return view('admin.user.detail',compact('user','shippings','search'));
+        $shippings = Shipping::where('id_user', $user->id)
+            ->where(function ($query) use ($search) {
+                $query->where('company_name', 'like', "%" . $search . "%")
+                    ->orWhere('country', 'like', "%" . $search . "%")
+                    ->orWhere('name', 'like', "%" . $search . "%")
+                    ->orWhere('address', 'like', "%" . $search . "%")
+                    ->orWhere('province', 'like', "%" . $search . "%")
+                    ->orWhere('zip', 'like', "%" . $search . "%")
+                    ->orWhere('email', 'like', "%" . $search . "%")
+                    ->orWhere('phone', 'like', "%" . $search . "%");
+            })->get();
+
+        return view('admin.user.detail', compact('user', 'shippings', 'search'));
     }
 }


### PR DESCRIPTION
The `shippingSearch` method in `UserController` was inefficient and logically incorrect. It performed a search across the entire `shippings` table if the user had at least one record, instead of limiting the search to that specific user's records. 

### Optimization Details:
- **Query Scoping:** Added `where('id_user', $user->id)` as the primary constraint.
- **Query Grouping:** Used a nested closure for search filters to maintain proper `AND (OR OR OR)` logic.
- **Redundancy Removal:** Eliminated the unnecessary `Shipping::where(...)->first()` check.
- **Bug Fix:** Corrected the search field from `state` to `province` to match the database migration and model definition.

### Performance Impact:
- Complexity reduced from $O(N)$ (total records) to $O(M)$ (user records).
- Number of queries reduced from 2 to 1.
- Fixes a security bug where search results included records from other users.

---
*PR created automatically by Jules for task [10472233232711280088](https://jules.google.com/task/10472233232711280088) started by @NeddyAP*