### PR TITLE
Refactor: Remove unused MustVerifyEmail import in User model

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,7 +2,6 @@
 
 namespace App\Models;
 
-use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
@@ -17,7 +16,7 @@ class User extends Authenticatable
      * @var array
      */
     protected $fillable = [
-        'name', 'email', 'password', 'phone', 'address'
+        'name', 'email', 'password', 'phone', 'address',
     ];
 
     /**


### PR DESCRIPTION
Removed the unused `Illuminate\Contracts\Auth\MustVerifyEmail` import from `app/Models/User.php`.
Verified that the import is not used in the class and that removing it does not cause any regressions in tests.
Also ran `pint` which added a trailing comma to the `$fillable` array.

---
*PR created automatically by Jules for task [8648187058385087657](https://jules.google.com/task/8648187058385087657) started by @NeddyAP*