### PR TITLE
⚡ Optimize ProductController: Remove redundant query in constructor

### DIFF
--- a/app/Http/Controllers/Admin/ProductController.php
+++ b/app/Http/Controllers/Admin/ProductController.php
@@ -9,11 +9,6 @@ use Illuminate\Http\Request;
 
 class ProductController extends Controller
 {
-    public function __construct()
-    {
-        $products = Product::orderBy('created_at', 'desc')->paginate(18);
-    }
-
     public function index()
     {
         $products = Product::orderBy('created_at', 'desc')->paginate(18);

--- a/tests/Feature/ProductControllerPerformanceTest.php
+++ b/tests/Feature/ProductControllerPerformanceTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Http\Controllers\Admin\ProductController;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class ProductControllerPerformanceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_product_controller_constructor_performance()
+    {
+        // Enable query log
+        DB::enableQueryLog();
+
+        // Instantiate the controller
+        $controller = new ProductController();
+
+        // Get executed queries
+        $queries = DB::getQueryLog();
+
+        // There should be NO queries executed in the constructor
+        $this->assertCount(0, $queries, 'Redundant queries found in ProductController constructor');
+    }
+}


### PR DESCRIPTION
This PR optimizes `App\Http\Controllers\Admin\ProductController` by removing a redundant database query in the constructor. The query `Product::orderBy('created_at', 'desc')->paginate(18);` was executed on every instantiation of the controller but the result was never used.

I have verified the fix by adding a regression test `tests/Feature/ProductControllerPerformanceTest.php` which asserts that 0 queries are executed when instantiating the controller.

**Performance Improvement:**
- Before: 1 redundant query per request to `ProductController`.
- After: 0 redundant queries.

**Testing:**
- Added `tests/Feature/ProductControllerPerformanceTest.php` (Passes).
- Verified `tests/Feature/ProductTest.php` (Passes).
- Note: `tests/Feature/ProductSecurityTest.php` fails due to a pre-existing issue (missing `clean()` helper), unrelated to this change.

---
*PR created automatically by Jules for task [8384425905985716947](https://jules.google.com/task/8384425905985716947) started by @NeddyAP*