### PR TITLE
Fix redundant semicolon in ShippingController

### DIFF
--- a/app/Http/Controllers/Admin/ShippingController.php
+++ b/app/Http/Controllers/Admin/ShippingController.php
@@ -3,35 +3,40 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Http\Request;
 use App\Models\Shipping;
 use App\Models\User;
+use Illuminate\Http\Request;
 
 class ShippingController extends Controller
 {
     public function index()
     {
         $shippings = Shipping::paginate(10);
-        return view('admin.shipping.index',compact('shippings'));
+
+        return view('admin.shipping.index', compact('shippings'));
     }
+
     public function search(Request $request)
     {
         $search = $request->search;
-        $shippings = Shipping::where('company_name', 'like', "%" . $search . "%")
-        ->orWhere('country', 'like', "%" . $search . "%")
-        ->orWhere('name', 'like', "%" . $search . "%")
-        ->orWhere('address', 'like', "%" . $search . "%")
-        ->orWhere('province', 'like', "%" . $search . "%")
-        ->orWhere('zip', 'like', "%" . $search . "%")
-        ->orWhere('email', 'like', "%" . $search . "%")
-        ->orWhere('phone', 'like', "%" . $search . "%")
-        ->paginate(10);
-        return view('admin.shipping.index',compact('shippings','search'));;
+        $shippings = Shipping::where('company_name', 'like', '%'.$search.'%')
+            ->orWhere('country', 'like', '%'.$search.'%')
+            ->orWhere('name', 'like', '%'.$search.'%')
+            ->orWhere('address', 'like', '%'.$search.'%')
+            ->orWhere('province', 'like', '%'.$search.'%')
+            ->orWhere('zip', 'like', '%'.$search.'%')
+            ->orWhere('email', 'like', '%'.$search.'%')
+            ->orWhere('phone', 'like', '%'.$search.'%')
+            ->paginate(10);
+
+        return view('admin.shipping.index', compact('shippings', 'search'));
     }
+
     public function detail($id)
     {
         $shipping = Shipping::find($id);
         $user = User::find($shipping->id_user);
-        return view('admin.shipping.detail',compact('shipping', 'user'));
+
+        return view('admin.shipping.detail', compact('shipping', 'user'));
     }
 }

--- a/tests/Feature/Admin/ShippingControllerTest.php
+++ b/tests/Feature/Admin/ShippingControllerTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use App\Models\Admin;
+use App\Models\User;
+use App\Models\Shipping;
+
+class ShippingControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_search_shippings()
+    {
+        // Create an admin user
+        $admin = Admin::create([
+            'name' => 'Admin User',
+            'email' => 'admin@example.com',
+            'password' => bcrypt('password'),
+        ]);
+
+        // Create a regular user for the shipping record
+        $user = User::factory()->create();
+
+        // Create a shipping record
+        Shipping::create([
+            'id_user' => $user->id,
+            'name' => 'John Doe',
+            'company_name' => 'Acme Corp',
+            'address' => '123 Main St',
+            'province' => 'Test Province',
+            'zip' => '12345',
+            'country' => 'Test Country',
+            'email' => 'john@example.com',
+            'phone' => '1234567890',
+            'notes' => 'Test notes',
+        ]);
+
+        // Act as the admin
+        $this->actingAs($admin, 'admin');
+
+        // Perform the search
+        $response = $this->get('/admin/shipping/search?search=Acme');
+
+        // Assert the response is successful
+        $response->assertStatus(200);
+        $response->assertViewIs('admin.shipping.index');
+        $response->assertViewHas('shippings');
+
+        // Assert the shipping record is in the view data
+        $shippings = $response->viewData('shippings');
+        $this->assertNotEmpty($shippings);
+        $this->assertEquals('Acme Corp', $shippings->first()->company_name);
+    }
+}


### PR DESCRIPTION
- 🎯 **What:** Removed an extra semicolon (`;;`) at the end of the `search` method in `app/Http/Controllers/Admin/ShippingController.php`.
- 💡 **Why:** To improve code health and maintainability by removing redundant code and adhering to coding standards. Also applied `pint` formatting for cleaner code.
- ✅ **Verification:** Created a new feature test `tests/Feature/Admin/ShippingControllerTest.php` which verifies the search functionality works as expected. Ran `pint` to ensure style compliance.
- ✨ **Result:** Cleaner, standard-compliant code with regression test coverage.

---
*PR created automatically by Jules for task [12726101283599853814](https://jules.google.com/task/12726101283599853814) started by @NeddyAP*