### PR TITLE
Improve testing for CartController update quantity logic and fix flash message

### DIFF
--- a/app/Http/Controllers/Front/CartController.php
+++ b/app/Http/Controllers/Front/CartController.php
@@ -43,7 +43,7 @@ class CartController extends Controller
         }
 
         // return $cart;
-        return redirect()->back()->with('danger', 'Artikel Berhasil Dihapus');
+        return redirect()->back()->with('success', 'Artikel Berhasil Ditambahkan');
     }
 
     public function delete($id)

--- a/tests/Feature/CartAddTest.php
+++ b/tests/Feature/CartAddTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Cart;
+use App\Models\Product;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CartAddTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Test that adding an existing product to the cart updates the quantity.
+     *
+     * @return void
+     */
+    public function test_update_cart_quantity_for_existing_item()
+    {
+        // 1. Create User
+        $user = User::factory()->create();
+
+        // 2. Create Product
+        $product = Product::factory()->create([
+            'price' => 100,
+            'qty' => 50,
+        ]);
+
+        // 3. Create existing Cart item
+        $initialQty = 2;
+        $cart = Cart::factory()->create([
+            'id_user' => $user->id,
+            'id_product' => $product->id,
+            'qty' => $initialQty,
+            'total' => $product->price * $initialQty,
+        ]);
+
+        // 4. Act as user and make request
+        $addQty = 3;
+        $response = $this->actingAs($user)
+            ->post(route('cart.add', ['id' => $product->id]), [
+                'qty' => $addQty,
+                'color' => 'red', // assuming color is required or optional
+            ]);
+
+        // 5. Assertions
+        $response->assertStatus(302); // Redirect back
+        $response->assertSessionHas('success', 'Artikel Berhasil Ditambahkan');
+
+        // Reload cart from database
+        $cart->refresh();
+
+        // Check if quantity is updated
+        $this->assertEquals($initialQty + $addQty, $cart->qty);
+    }
+
+    /**
+     * Test that adding a new product to the cart creates a new cart item.
+     *
+     * @return void
+     */
+    public function test_add_new_item_to_cart()
+    {
+        // 1. Create User
+        $user = User::factory()->create();
+
+        // 2. Create Product
+        $product = Product::factory()->create([
+            'price' => 100,
+            'qty' => 50,
+        ]);
+
+        // 3. Act as user and make request
+        $qty = 2;
+        $color = 'blue';
+        $response = $this->actingAs($user)
+            ->post(route('cart.add', ['id' => $product->id]), [
+                'qty' => $qty,
+                'color' => $color,
+            ]);
+
+        // 4. Assertions
+        $response->assertStatus(302); // Redirect back
+        $response->assertSessionHas('success', 'Artikel Berhasil Ditambahkan');
+
+        // Check database
+        $this->assertDatabaseHas('carts', [
+            'id_user' => $user->id,
+            'id_product' => $product->id,
+            'qty' => $qty,
+            'color' => $color,
+            'total' => $product->price * $qty,
+        ]);
+    }
+}


### PR DESCRIPTION
Added `tests/Feature/CartAddTest.php` to verify that adding an existing product to the cart correctly updates the quantity instead of creating a duplicate. Also fixed a copy-paste error in `CartController::add` where the flash message was 'Artikel Berhasil Dihapus' (Item Deleted) instead of 'Artikel Berhasil Ditambahkan' (Item Added), and updated tests to assert the correct message.

---
*PR created automatically by Jules for task [12057258595856338863](https://jules.google.com/task/12057258595856338863) started by @NeddyAP*