### PR TITLE
Refactor: Remove unused database query in ProductController constructor

### DIFF
--- a/app/Http/Controllers/Admin/ProductController.php
+++ b/app/Http/Controllers/Admin/ProductController.php
@@ -9,11 +9,6 @@ use Illuminate\Http\Request;
 
 class ProductController extends Controller
 {
-    public function __construct()
-    {
-        $products = Product::orderBy('created_at', 'desc')->paginate(18);
-    }
-
     public function index()
     {
         $products = Product::orderBy('created_at', 'desc')->paginate(18);

--- a/tests/Feature/Admin/ProductControllerTest.php
+++ b/tests/Feature/Admin/ProductControllerTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\Admin;
+use App\Models\Product;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ProductControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_can_view_product_index()
+    {
+        $admin = Admin::create([
+            'name' => 'Admin User',
+            'email' => 'admin@example.com',
+            'password' => bcrypt('password'),
+        ]);
+
+        Product::factory()->count(3)->create();
+
+        $response = $this->actingAs($admin, 'admin')
+            ->get(route('products.index'));
+
+        $response->assertStatus(200);
+        $response->assertViewIs('admin.product.index');
+        $response->assertViewHas('products');
+    }
+}


### PR DESCRIPTION
Removed the unused `__construct` method in `App\Http\Controllers\Admin\ProductController.php`.
The constructor was executing a database query `Product::orderBy('created_at', 'desc')->paginate(18)` and assigning it to a local variable `$products`, which was never used.
Added `tests/Feature/Admin/ProductControllerTest.php` to verify that the `index` method of the controller still works correctly.

Note: `tests/Feature/ProductSecurityTest.php` is failing due to a pre-existing issue (missing `mews/purifier` dependency causing undefined `clean()` function), which is outside the scope of this refactoring. My changes do not affect this failure (verified by reverting unrelated dependency changes).

---
*PR created automatically by Jules for task [818181905857884701](https://jules.google.com/task/818181905857884701) started by @NeddyAP*