### PR TITLE
🧹 Remove unused Request import in ShopController

### DIFF
--- a/app/Http/Controllers/Front/ShopController.php
+++ b/app/Http/Controllers/Front/ShopController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers\Front;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Http\Request;
 use App\Models\Product;
 
 class ShopController extends Controller

--- a/tests/Feature/Front/ShopControllerTest.php
+++ b/tests/Feature/Front/ShopControllerTest.php
@@ -43,4 +43,29 @@ class ShopControllerTest extends TestCase
         // Assert response is 404
         $response->assertStatus(404);
     }
+
+    /** @test */
+    public function test_index_method()
+    {
+        // Create products
+        Product::create([
+            'name' => 'Test Product 1',
+            'price' => 100,
+            'spec' => 'Test Spec',
+            'qty' => 10,
+            'category' => 'laptop',
+            'status' => 'Available',
+            'desc' => 'Test Description',
+            'img' => 'test1.jpg'
+        ]);
+
+        // Make a GET request
+        $response = $this->get(route('shop'));
+
+        // Assert response
+        $response->assertStatus(200);
+        $response->assertViewIs('front.shop.index');
+        $response->assertViewHas('products');
+        $response->assertViewHas('random');
+    }
 }


### PR DESCRIPTION
This PR removes the unused `Illuminate\Http\Request` import from `app/Http/Controllers/Front/ShopController.php`.
It also adds a test case for the `index` method to ensure that the controller continues to function correctly and that inheritance is not affected.
This improves code readability and maintainability.

---
*PR created automatically by Jules for task [17206391109755483361](https://jules.google.com/task/17206391109755483361) started by @NeddyAP*