### PR TITLE
Refactor orderDetail model to OrderDetail

### DIFF
--- a/app/Http/Controllers/Front/OrderController.php
+++ b/app/Http/Controllers/Front/OrderController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers\Front;
 
 use App\Models\Order;
 use App\Models\Cart;
-use App\Models\orderDetail;
+use App\Models\OrderDetail;
 use App\Models\Shipping;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
@@ -50,7 +50,7 @@ class OrderController extends Controller
         ->select('carts.*','products.name','products.price','products.new_price','products.img','products.category');
         $carts = $all_cart->get();
         foreach($carts as $cart){
-            orderDetail::create([
+            OrderDetail::create([
                 'id_order' => $order->id,
                 'id_user' => $userId,
                 'id_product' => $cart->id_product,

--- a/app/Http/Controllers/OrderDetailController.php
+++ b/app/Http/Controllers/OrderDetailController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers;
 
-use App\orderDetail;
+use App\Models\OrderDetail;
 use Illuminate\Http\Request;
 
 class OrderDetailController extends Controller
@@ -41,10 +41,10 @@ class OrderDetailController extends Controller
     /**
      * Display the specified resource.
      *
-     * @param  \App\orderDetail  $orderDetail
+     * @param  \App\Models\OrderDetail  $orderDetail
      * @return \Illuminate\Http\Response
      */
-    public function show(orderDetail $orderDetail)
+    public function show(OrderDetail $orderDetail)
     {
         //
     }
@@ -52,10 +52,10 @@ class OrderDetailController extends Controller
     /**
      * Show the form for editing the specified resource.
      *
-     * @param  \App\orderDetail  $orderDetail
+     * @param  \App\Models\OrderDetail  $orderDetail
      * @return \Illuminate\Http\Response
      */
-    public function edit(orderDetail $orderDetail)
+    public function edit(OrderDetail $orderDetail)
     {
         //
     }
@@ -64,10 +64,10 @@ class OrderDetailController extends Controller
      * Update the specified resource in storage.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  \App\orderDetail  $orderDetail
+     * @param  \App\Models\OrderDetail  $orderDetail
      * @return \Illuminate\Http\Response
      */
-    public function update(Request $request, orderDetail $orderDetail)
+    public function update(Request $request, OrderDetail $orderDetail)
     {
         //
     }
@@ -75,10 +75,10 @@ class OrderDetailController extends Controller
     /**
      * Remove the specified resource from storage.
      *
-     * @param  \App\orderDetail  $orderDetail
+     * @param  \App\Models\OrderDetail  $orderDetail
      * @return \Illuminate\Http\Response
      */
-    public function destroy(orderDetail $orderDetail)
+    public function destroy(OrderDetail $orderDetail)
     {
         //
     }

--- a/app/Models/OrderDetail.php
+++ b/app/Models/OrderDetail.php
@@ -2,10 +2,13 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
-class orderDetail extends Model
+class OrderDetail extends Model
 {
+    use HasFactory;
+
     protected $table = 'order_details';
     protected $fillable = [
         'id_user', 'id_order', 'id_product', 'color', 'qty', 'total'

--- a/database/factories/OrderDetailFactory.php
+++ b/database/factories/OrderDetailFactory.php
@@ -1,12 +1,31 @@
 <?php
 
-/** @var \Illuminate\Database\Eloquent\Factory $factory */
+namespace Database\Factories;
 
-use App\orderDetail;
-use Faker\Generator as Faker;
+use App\Models\OrderDetail;
+use Illuminate\Database\Eloquent\Factories\Factory;
 
-$factory->define(orderDetail::class, function (Faker $faker) {
-    return [
-        //
-    ];
-});
+class OrderDetailFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = OrderDetail::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'color' => $this->faker->colorName(),
+            'qty' => $this->faker->numberBetween(1, 10),
+            'total' => $this->faker->numberBetween(100, 1000),
+            // Foreign keys: id_user, id_order, id_product will be provided by tests
+        ];
+    }
+}

--- a/tests/Unit/Models/OrderDetailTest.php
+++ b/tests/Unit/Models/OrderDetailTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\OrderDetail;
+use App\Models\User;
+use App\Models\Product;
+use App\Models\Order;
+use App\Models\Shipping;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class OrderDetailTest extends TestCase
+{
+    use RefreshDatabase;
+    use WithFaker;
+
+    /**
+     * Test that an order detail can be created using the factory.
+     */
+    public function test_order_detail_can_be_created_with_factory()
+    {
+        // Create dependencies
+        $user = User::factory()->create();
+        $product = Product::factory()->create();
+
+        // Create Shipping manually
+        $shipping = Shipping::create([
+             'id_user' => $user->id,
+             'country' => 'Test Country',
+             'name' => 'Test Name',
+             'company_name' => 'Test Company',
+             'address' => 'Test Address',
+             'province' => 'Test Province',
+             'zip' => '12345',
+             'email' => 'test@example.com',
+             'phone' => '1234567890',
+        ]);
+
+        // Manually create an order
+        $order = Order::create([
+             'code' => 'TEST-' . uniqid(),
+             'id_user' => $user->id,
+             'id_shipping' => $shipping->id,
+             'total' => 100,
+             'status_product' => 'Pending',
+             'status_user' => 'Pending',
+        ]);
+
+        // Create OrderDetail using factory
+        $orderDetail = OrderDetail::factory()->create([
+            'id_user' => $user->id,
+            'id_order' => $order->id,
+            'id_product' => $product->id,
+        ]);
+
+        $this->assertModelExists($orderDetail);
+        $this->assertDatabaseCount('order_details', 1);
+
+        $this->assertEquals($user->id, $orderDetail->id_user);
+        $this->assertEquals($order->id, $orderDetail->id_order);
+        $this->assertEquals($product->id, $orderDetail->id_product);
+    }
+
+    /**
+     * Test order detail fillable attributes.
+     */
+    public function test_order_detail_fillable_attributes()
+    {
+        $orderDetail = new OrderDetail();
+        $expectedFillable = ['id_user', 'id_order', 'id_product', 'color', 'qty', 'total'];
+
+        $this->assertEquals($expectedFillable, $orderDetail->getFillable());
+    }
+
+    /**
+     * Test that an order detail can be created using create method.
+     */
+    public function test_order_detail_can_be_created_explicitly()
+    {
+        // Create dependencies
+        $user = User::factory()->create();
+        $product = Product::factory()->create();
+
+        // Create Shipping manually
+        $shipping = Shipping::create([
+             'id_user' => $user->id,
+             'country' => 'Test Country',
+             'name' => 'Test Name',
+             'company_name' => 'Test Company',
+             'address' => 'Test Address',
+             'province' => 'Test Province',
+             'zip' => '12345',
+             'email' => 'test@example.com',
+             'phone' => '1234567890',
+        ]);
+
+        // Manually create an order
+        $order = Order::create([
+             'code' => 'TEST-' . uniqid(),
+             'id_user' => $user->id,
+             'id_shipping' => $shipping->id,
+             'total' => 100,
+             'status_product' => 'Pending',
+             'status_user' => 'Pending',
+        ]);
+
+        // Create OrderDetail using create
+        $orderDetail = OrderDetail::create([
+            'id_user' => $user->id,
+            'id_order' => $order->id,
+            'id_product' => $product->id,
+            'color' => 'Blue',
+            'qty' => 2,
+            'total' => 50,
+        ]);
+
+        $this->assertModelExists($orderDetail);
+        $this->assertDatabaseCount('order_details', 1);
+
+        $this->assertEquals($user->id, $orderDetail->id_user);
+        $this->assertEquals($order->id, $orderDetail->id_order);
+        $this->assertEquals($product->id, $orderDetail->id_product);
+        $this->assertEquals('Blue', $orderDetail->color);
+        $this->assertEquals(2, $orderDetail->qty);
+        $this->assertEquals(50, $orderDetail->total);
+    }
+}


### PR DESCRIPTION
This PR addresses a code health issue by renaming the `orderDetail` model to `OrderDetail` to follow PSR-4 and Laravel naming conventions. It also modernizes the factory to use the class-based approach and adds unit tests to ensure correctness. No existing tests were broken as there were no prior tests for this model.

---
*PR created automatically by Jules for task [9717462430685790017](https://jules.google.com/task/9717462430685790017) started by @NeddyAP*