### PR TITLE
Refactor Admin controllers to remove redundant base class

### DIFF
--- a/app/Http/Controllers/Admin/CartController.php
+++ b/app/Http/Controllers/Admin/CartController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Admin;
 
+use App\Http\Controllers\Controller;
 use App\Models\Cart;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;

--- a/app/Http/Controllers/Admin/CartDetailsController.php
+++ b/app/Http/Controllers/Admin/CartDetailsController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Admin;
 
+use App\Http\Controllers\Controller;
 use App\Models\CartDetails;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;

--- a/app/Http/Controllers/Admin/Controller.php
+++ b/app/Http/Controllers/Admin/Controller.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace App\Http\Controllers\Admin;
-
-use App\Http\Controllers\Controller as BaseController;
-
-class Controller extends BaseController
-{
-}

--- a/app/Http/Controllers/Admin/DashboardController.php
+++ b/app/Http/Controllers/Admin/DashboardController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Admin;
 
+use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 
 class DashboardController extends Controller

--- a/app/Http/Controllers/Admin/ProductController.php
+++ b/app/Http/Controllers/Admin/ProductController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Admin;
 
+use App\Http\Controllers\Controller;
 use App\Models\Product;
 use File;
 use Image;

--- a/app/Http/Controllers/Admin/TransactionController.php
+++ b/app/Http/Controllers/Admin/TransactionController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Admin;
 
+use App\Http\Controllers\Controller;
 use App\Models\Transaction;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;


### PR DESCRIPTION
This change addresses a code health issue where `app/Http/Controllers/Admin/Controller.php` was identified as a duplicate or redundant class. The class was empty and merely extended the base `App\Http\Controllers\Controller`. 

I have:
1.  Verified that `app/Http/Controllers/Admin/Controller.php` contained no logic.
2.  Updated all controllers in the `Admin` namespace that were implicitly extending it to explicitly import and extend `App\Http\Controllers\Controller`.
3.  Deleted `app/Http/Controllers/Admin/Controller.php`.
4.  Verified the changes by running syntax checks and executing `tests/Feature/ProductSecurityTest.php` to ensure controller loading and inheritance still work correctly.

---
*PR created automatically by Jules for task [3366543642155775984](https://jules.google.com/task/3366543642155775984) started by @NeddyAP*