### PR TITLE
Refactor duplicated cart query logic to Cart model scope

### DIFF
--- a/app/Http/Controllers/Front/CartController.php
+++ b/app/Http/Controllers/Front/CartController.php
@@ -16,8 +16,7 @@ class CartController extends Controller
 
     public function index()
     {
-        $carts = Cart::where('id_user', Auth::user()->id)->join('products', 'products.id', '=', 'carts.id_product')
-            ->select('carts.*', 'products.name', 'products.price', 'products.new_price', 'products.img', 'products.category')->get();
+        $carts = Cart::forUser(Auth::user()->id)->get();
 
         // return $carts;
         return view('front.cart.index', compact('carts'));
@@ -59,8 +58,7 @@ class CartController extends Controller
 
     public function checkout()
     {
-        $carts = Cart::where('id_user', Auth::user()->id)->join('products', 'products.id', '=', 'carts.id_product')
-            ->select('carts.*', 'products.name', 'products.price', 'products.new_price', 'products.img', 'products.category')->get();
+        $carts = Cart::forUser(Auth::user()->id)->get();
 
         return view('front.cart.checkout', compact('carts'));
     }

--- a/app/Http/Controllers/Front/OrderController.php
+++ b/app/Http/Controllers/Front/OrderController.php
@@ -2,13 +2,13 @@
 
 namespace App\Http\Controllers\Front;
 
-use App\Models\Order;
 use App\Models\Cart;
+use App\Models\Order;
 use App\Models\orderDetail;
 use App\Models\Shipping;
-use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Str;
 
 class OrderController extends Controller
 {
@@ -17,11 +17,11 @@ class OrderController extends Controller
         $this->middleware('auth');
     }
 
-    public function create(Request $request ,$id)
+    public function create(Request $request, $id)
     {
         $userId = Auth::id();
 
-        #Shipping
+        // Shipping
         $shipping = Shipping::create([
             'id_user' => $userId,
             'country' => $request->country,
@@ -35,7 +35,7 @@ class OrderController extends Controller
             'notes' => $request->notes ? strip_tags($request->notes) : null,
         ]);
 
-        #Order
+        // Order
         $order = Order::create([
             'code' => 'TCP-'.Str::random(5).now()->format('-mdY'),
             'total' => $request->total,
@@ -45,11 +45,10 @@ class OrderController extends Controller
             'status_user' => 'Proccess',
         ]);
 
-        #Order Details
-        $all_cart = Cart::where('id_user', $userId)->join('products','products.id','=','carts.id_product')
-        ->select('carts.*','products.name','products.price','products.new_price','products.img','products.category');
+        // Order Details
+        $all_cart = Cart::forUser($userId);
         $carts = $all_cart->get();
-        foreach($carts as $cart){
+        foreach ($carts as $cart) {
             orderDetail::create([
                 'id_order' => $order->id,
                 'id_user' => $userId,
@@ -58,11 +57,12 @@ class OrderController extends Controller
                 'qty' => $cart->qty,
                 'total' => $cart->total,
             ]);
-        };
+        }
 
         $shipping->save();
         $order->save();
         $all_cart->delete();
+
         return view('front.order.thankyou');
     }
 }

--- a/app/Models/Cart.php
+++ b/app/Models/Cart.php
@@ -10,7 +10,15 @@ class Cart extends Model
     use HasFactory;
 
     protected $table = 'carts';
+
     protected $fillable = [
-        'id_user', 'id_product', 'color', 'qty', 'total'
+        'id_user', 'id_product', 'color', 'qty', 'total',
     ];
+
+    public function scopeForUser($query, $userId)
+    {
+        return $query->where('id_user', $userId)
+            ->join('products', 'products.id', '=', 'carts.id_product')
+            ->select('carts.*', 'products.name', 'products.price', 'products.new_price', 'products.img', 'products.category');
+    }
 }


### PR DESCRIPTION
This PR addresses a code health issue by refactoring duplicated cart query logic found in `CartController` and `OrderController`.

**Changes:**
- Added `scopeForUser` method to `App\Models\Cart`.
- Refactored `App\Http\Controllers\Front\CartController` to use `Cart::forUser()`.
- Refactored `App\Http\Controllers\Front\OrderController` to use `Cart::forUser()`.

**Verification:**
- Ran `php artisan test tests/Feature/CartTest.php` - Passed.
- Ran `php artisan test tests/Feature/OrderIdorTest.php` - Passed.
- Ran `./vendor/bin/pint` to ensure code style compliance.

---
*PR created automatically by Jules for task [5783651863283809791](https://jules.google.com/task/5783651863283809791) started by @NeddyAP*