### PR TITLE
⚡ Optimize ProductController search query and pagination

### DIFF
--- a/app/Http/Controllers/Admin/ProductController.php
+++ b/app/Http/Controllers/Admin/ProductController.php
@@ -4,19 +4,15 @@ namespace App\Http\Controllers\Admin;
 
 use App\Models\Product;
 use File;
-use Image;
 use Illuminate\Http\Request;
+use Image;
 
 class ProductController extends Controller
 {
-    public function __construct()
-    {
-        $products = Product::orderBy('created_at', 'desc')->paginate(18);
-    }
-
     public function index()
     {
         $products = Product::orderBy('created_at', 'desc')->paginate(18);
+
         return view('admin.product.index', compact('products'));
         // ->with('no', (request()->input('page', 1) - 1) * 5)
     }
@@ -24,21 +20,22 @@ class ProductController extends Controller
     public function search(Request $request)
     {
         $search = $request->search;
-        $result = Product::where('name', 'like', "%" . $search . "%")
-        ->orWhere('price', 'like', "%" . $search . "%")
-        ->orWhere('category', 'like', "%" . $search . "%")
-        ->orWhere('status', 'like', "%" . $search . "%")
-        ->orderBy('created_at', 'desc')->paginate(18);
-        $products = Product::orderBy('created_at', 'desc')->paginate(18);
+        $products = Product::where('name', 'like', '%'.$search.'%')
+            ->orWhere('price', 'like', '%'.$search.'%')
+            ->orWhere('category', 'like', '%'.$search.'%')
+            ->orWhere('status', 'like', '%'.$search.'%')
+            ->orderBy('created_at', 'desc')->paginate(18);
+        $products->appends(['search' => $search]);
+        $result = $products;
+
         // dd($result);
-        return view('admin.product.index', compact('result','products'));
+        return view('admin.product.index', compact('result', 'products'));
     }
 
     public function create()
     {
         return view('admin.product.actions.input');
     }
-
 
     public function store(Request $request)
     {
@@ -49,13 +46,11 @@ class ProductController extends Controller
             'spec' => 'required|min:3',
             'qty' => 'required|integer',
             'desc' => 'required',
-            'img' => 'required|image|max:2048'
+            'img' => 'required|image|max:2048',
         ]);
 
-
         $image = $request->file('img');
-        $filename = \Carbon\Carbon::now()->timestamp . '_' . uniqid() . '.' . $image->getClientOriginalExtension();
-
+        $filename = \Carbon\Carbon::now()->timestamp.'_'.uniqid().'.'.$image->getClientOriginalExtension();
 
         // Thumbnail Image
         $destinationPath = public_path('asset/'.$request->category.'/thumbnail');
@@ -76,14 +71,13 @@ class ProductController extends Controller
             $constraint->aspectRatio();
         })->save($destinationPath.'/'.$filename);
 
-        //////// 285
+        // ////// 285
         $destinationPath = public_path('asset/'.$request->category.'/285');
         File::exists($destinationPath) or File::makeDirectory($destinationPath, 0777, true, true);
         $img = Image::make($image->path());
         $img->resize(285, 400, function ($constraint) {
             $constraint->aspectRatio();
         })->save($destinationPath.'/'.$filename);
-
 
         // Original Image
         $destinationPath = public_path('asset/'.$request->category.'/');
@@ -106,27 +100,25 @@ class ProductController extends Controller
             'color' => $request->color,
             'img' => $filename,
         ]);
-        $tags = explode(",", $request->color);
+        $tags = explode(',', $request->color);
         $product->tag($tags);
 
         // Product::create($request->all());
         return redirect(route('products.index'));
     }
 
-
     public function show(Product $product)
     {
         //
     }
 
-
     public function edit($id)
     {
         $products = Product::all();
         $product = $products->find($id);
+
         return view('admin.product.actions.edit', compact('product'));
     }
-
 
     public function update(Request $request, $id)
     {
@@ -140,16 +132,15 @@ class ProductController extends Controller
             'qty' => 'required|integer',
             'desc' => 'required',
             'color' => 'required',
-            'img' => 'image|max:2048'
+            'img' => 'image|max:2048',
         ]);
         if ($request->hasFile('img')) {
-            File::delete(public_path('asset/'.$product->category.'/thumbnail/'). $product->img);
-            File::delete(public_path('asset/'.$product->category.'/285/'). $product->img);
-            File::delete(public_path('asset/'.$product->category.'/'). $product->img);
+            File::delete(public_path('asset/'.$product->category.'/thumbnail/').$product->img);
+            File::delete(public_path('asset/'.$product->category.'/285/').$product->img);
+            File::delete(public_path('asset/'.$product->category.'/').$product->img);
 
             $image = $request->file('img');
-            $filename = \Carbon\Carbon::now()->timestamp . '_' . uniqid() . '.' . $image->getClientOriginalExtension();
-
+            $filename = \Carbon\Carbon::now()->timestamp.'_'.uniqid().'.'.$image->getClientOriginalExtension();
 
             // Thumbnail Image
             $destinationPath = public_path('asset/'.$request->category.'/thumbnail');
@@ -160,7 +151,7 @@ class ProductController extends Controller
 
             $img = Image::make($image->path());
             $img->resize(400, 400, function ($constraint) {
-            $constraint->aspectRatio();
+                $constraint->aspectRatio();
             });
             // $canvas->save($destinationPath.'/'.$filename);
             $canvas->insert($img, 'center')->save($destinationPath.'/'.$filename);
@@ -177,15 +168,13 @@ class ProductController extends Controller
             $destinationPath = public_path('asset/'.$request->category.'/single');
             File::exists($destinationPath) or File::makeDirectory($destinationPath, 0777, true, true);
             $img = Image::make($image->path());
-            $img->resize(500,500, function ($constraint) {
+            $img->resize(500, 500, function ($constraint) {
                 $constraint->aspectRatio();
             })->save($destinationPath.'/'.$filename);
-
 
             // Original Image
             $destinationPath = public_path('asset/'.$request->category.'/');
             $image->move($destinationPath, $filename);
-
 
             // $image = $request->file('img');
             // $filename = \Carbon\Carbon::now()->timestamp . '_' . uniqid() . '.' . $image->getClientOriginalExtension();
@@ -204,7 +193,7 @@ class ProductController extends Controller
             'desc' => clean($request->desc),
             'color' => $request->color,
         ]);
-        $tags = explode(",", $request->color);
+        $tags = explode(',', $request->color);
         $product->tag($tags);
 
         return redirect(route('products.index'));
@@ -214,14 +203,16 @@ class ProductController extends Controller
     {
         $product = Product::find($id);
         $product->update([
-            'status' => 'Trash'
+            'status' => 'Trash',
         ]);
+
         return redirect(route('products.index'));
     }
 
     public function destroy($id)
     {
         Product::find($id)->delete();
+
         return redirect()->back();
     }
 }

--- a/tests/Feature/Admin/ProductSearchPerformanceTest.php
+++ b/tests/Feature/Admin/ProductSearchPerformanceTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\Admin;
+use App\Models\Product;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class ProductSearchPerformanceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_redundant_product_query_is_not_executed_during_search()
+    {
+        // Setup admin user
+        $admin = Admin::create([
+            'name' => 'Admin',
+            'email' => 'admin@example.com',
+            'password' => bcrypt('password'),
+        ]);
+
+        $searchTerm = 'something';
+
+        // Create enough products to trigger pagination (18 per page, so 20 is enough)
+        // Ensure they match the search term
+        Product::factory()->count(20)->create([
+            'name' => $searchTerm.' '.Str::random(5),
+        ]);
+
+        // Enable query logging
+        DB::enableQueryLog();
+
+        // Perform the search request
+        $response = $this->actingAs($admin, 'admin')
+            ->get(route('products.search', ['search' => $searchTerm]));
+
+        $response->assertStatus(200);
+
+        // Get executed queries
+        $queries = DB::getQueryLog();
+
+        // Filter for product selection queries
+        $productSelectQueries = array_filter($queries, function ($log) {
+            $query = strtolower($log['query']);
+
+            return str_contains($query, 'select') &&
+                   str_contains($query, 'products') &&
+                   str_contains($query, 'limit 18');
+        });
+
+        // We expect:
+        // 1. Search results (with WHERE clauses)
+        // 2. NO All products query (without WHERE clauses)
+
+        $redundantQueryFound = false;
+        foreach ($productSelectQueries as $log) {
+            $query = strtolower($log['query']);
+            // A query without "like" or specific where clauses is likely the redundant one fetching all products
+            if (! str_contains($query, 'like') && str_contains($query, 'order by "created_at" desc')) {
+                $redundantQueryFound = true;
+                break;
+            }
+        }
+
+        $this->assertFalse($redundantQueryFound, 'The redundant query fetching all products was found, but it should be removed.');
+
+        // Also verify that pagination links contain the search term
+        // The view contains {{ $products->links(...) }}
+        // The response content should have `search=something` in the links.
+        $response->assertSee('search='.$searchTerm);
+    }
+}


### PR DESCRIPTION
💡 **What:**
- Removed a redundant database query in `App\Http\Controllers\Admin\ProductController::search` that was fetching the first page of *all* products even when displaying search results.
- Removed the `__construct` method in `ProductController` which was executing the same redundant query on *every* instantiation of the controller (effectively every request handled by this controller), and discarding the result.
- Updated the search method to use the search results for the `$products` variable (used for badges and pagination links in the view), ensuring that pagination links now correctly refer to the search results instead of the full product list.
- Added `$products->appends(['search' => $search])` to ensure the search term is preserved when navigating through search result pages.
- Added a regression test `tests/Feature/Admin/ProductSearchPerformanceTest.php` to verify the redundant query is gone and pagination links are correct.

🎯 **Why:**
- Significant performance improvement by eliminating two heavy queries (one on every request, one on search).
- Fixed a bug where searching displayed correct results but the pagination links at the bottom would reset the search and show the second page of *all* products.
- Fixed a bug/confusion where the badges ("All", "Available", "Sold") were showing counts based on the current page of the full list, instead of being relevant to the search context (now they show counts based on the current page of search results, which is more consistent with the displayed list).

📊 **Measured Improvement:**
- Established a baseline where `ProductController::search` executed 4 queries (Count Search, Get Search, Count All, Get All) plus the constructor query.
- Optimized version executes only the necessary queries for the search results (Count Search, Get Search).
- Verified via `tests/Feature/Admin/ProductSearchPerformanceTest.php` that the query `select * from "products" order by "created_at" desc limit 18` is no longer executed during a search request.

---
*PR created automatically by Jules for task [14198712602002685475](https://jules.google.com/task/14198712602002685475) started by @NeddyAP*