### PR TITLE
🧹 remove commented-out middleware in Kernel.php

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -52,7 +52,6 @@ class Kernel extends HttpKernel
             EncryptCookies::class,
             AddQueuedCookiesToResponse::class,
             StartSession::class,
-            // \Illuminate\Session\Middleware\AuthenticateSession::class,
             ShareErrorsFromSession::class,
             VerifyCsrfToken::class,
             SubstituteBindings::class,


### PR DESCRIPTION
🎯 **What:** Removed a commented-out middleware entry in `app/Http/Kernel.php`.
💡 **Why:** Dead code in configuration files can cause confusion about which middleware are actually active. Removing it improves maintainability and readability.
✅ **Verification:** 
- Verified the removal of the line `// \Illuminate\Session\Middleware\AuthenticateSession::class,`.
- Ran `php -l app/Http/Kernel.php` to ensure no syntax errors.
- Confirmed the change is safe as it only removes a comment.
✨ **Result:** A cleaner and more maintainable `Kernel.php` file.

---
*PR created automatically by Jules for task [6214140629842011341](https://jules.google.com/task/6214140629842011341) started by @NeddyAP*